### PR TITLE
Pin Scala 3.3 LTS in scala steward

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -8,6 +8,8 @@ updates.pin = [
   { groupId = "org.apache.kafka", artifactId="kafka-clients", version="3.0." }
   # To be updated in tandem with upstream Akka
   { groupId = "org.scalatest", artifactId = "scalatest", version = "3.1." }
+  # Scala 3.3 is a LTS
+  { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.3." }
 ]
 
 commits.message = "bump: ${artifactName} ${nextVersion} (was ${currentVersion})"


### PR DESCRIPTION
I noticed in Scala OS projects that Scala Steward has been bumping 3.3.x to 3.4.x