### PR TITLE
pin to jackson 2.16

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -7,6 +7,8 @@ updates.pin = [
   { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox", version = "0.9." }
   # Pin logback to v1.3.x because v1.4.x needs JDK11
   { groupId = "ch.qos.logback", version="1.3." }
+  # Jackson 2.17.0 has some issues
+  { groupId = "com.fasterxml.jackson.core", version="2.16." }
   # Scala 3.3 is a LTS
   { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.3." }
 ]

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -7,7 +7,7 @@ updates.pin = [
   { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox", version = "0.9." }
   # Pin logback to v1.3.x because v1.4.x needs JDK11
   { groupId = "ch.qos.logback", version="1.3." }
-  # Jackson 2.17.0 has some issues
+  # https://github.com/apache/pekko/issues/1202
   { groupId = "com.fasterxml.jackson.core", version="2.16." }
   # Scala 3.3 is a LTS
   { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.3." }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -37,7 +37,7 @@ object Dependencies {
     "org.testcontainers" % "kafka" % testcontainersVersion % Test,
     "org.scalatest" %% "scalatest" % scalaTestVersion % Test,
     "io.spray" %% "spray-json" % "1.3.6" % Test,
-    "com.fasterxml.jackson.core" % "jackson-databind" % "2.14.3" % Test,
+    "com.fasterxml.jackson.core" % "jackson-databind" % "2.16.2" % Test,
     // See http://hamcrest.org/JavaHamcrest/distributables#upgrading-from-hamcrest-1x
     "org.hamcrest" % "hamcrest-library" % "2.2" % Test,
     "org.hamcrest" % "hamcrest" % "2.2" % Test,


### PR DESCRIPTION
I am a Jackson contributor and Jackson 2.17.0 has a number of issues. In other Pekko modules, we have stuck with 2.16.x, for now.