### PR TITLE
build with pekko 1.1

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
   push:
     branches:
-      - master
       - main
       - release-*
     tags-ignore: [ v.* ]

--- a/.github/workflows/nightly-pekko.yml
+++ b/.github/workflows/nightly-pekko.yml
@@ -52,7 +52,7 @@ jobs:
         uses: coursier/cache-action@v6
 
       - name: Run tests with Scala ${{ matrix.scala-version }} and Java ${{ matrix.java-version }}
-        run: sbt -Dpekko.build.pekko.version=1.0.x "++${{ matrix.scala-version }} test" ${{ matrix.sbt-opts }}
+        run: sbt -Dpekko.build.pekko.version=1.0.x "++${{ matrix.scala-version }} test"
 
       - name: Print logs on failure
         if: ${{ failure() }}

--- a/.github/workflows/nightly-pekko.yml
+++ b/.github/workflows/nightly-pekko.yml
@@ -1,4 +1,4 @@
-name: Nightly Test with Pekko 1.0 libs
+name: Nightly Test
 
 on:
   workflow_dispatch:
@@ -23,9 +23,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { java-version: 8,  scala-version: 2.12, sbt-opts: '' }
-          - { java-version: 8,  scala-version: 2.13, sbt-opts: '' }
-          - { java-version: 8,  scala-version: 3.3, sbt-opts: '' }
+          - { java-version: 8,  scala-version: 2.12, pekko-version: '1.0.x' }
+          - { java-version: 8,  scala-version: 2.12, pekko-version: 'main' }
+          - { java-version: 8,  scala-version: 2.13, pekko-version: '1.0.x' }
+          - { java-version: 8,  scala-version: 2.13, pekko-version: 'main' }
+          - { java-version: 8,  scala-version: 3.3, pekko-version: '1.0.x' }
+          - { java-version: 8,  scala-version: 3.3, pekko-version: 'main' }
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/nightly-pekko.yml
+++ b/.github/workflows/nightly-pekko.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:  
   test:
-    name: Build and Test with Pekko 1.0
+    name: Build and Test with Pekko ${{ matrix.pekko-version }}
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -51,15 +51,15 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6
 
-      - name: Run tests with Scala ${{ matrix.scala-version }} and Java ${{ matrix.java-version }}
-        run: sbt -Dpekko.build.pekko.version=1.0.x "++${{ matrix.scala-version }} test"
+      - name: Run tests with Scala ${{ matrix.scala-version }} and Java ${{ matrix.java-version }} with Pekko ${{ matrix.pekko-version }}
+        run: sbt -Dpekko.build.pekko.version=${{ matrix.pekko-version }} "++${{ matrix.scala-version }} test"
 
       - name: Print logs on failure
         if: ${{ failure() }}
         run: find . -name "*.log" -exec ./scripts/cat-log.sh {} \;
 
   integration-test:
-    name: Integration tests with Pekko 1.0
+    name: Integration tests with Pekko ${{ matrix.pekko-version }}
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -84,7 +84,7 @@ jobs:
         uses: coursier/cache-action@v6
 
       - name: Run multi-broker and long running integration tests
-        run: sbt -Dpekko.build.pekko.version=1.0.x "tests/IntegrationTest/test"
+        run: sbt -Dpekko.build.pekko.version=${{ matrix.pekko-version }} "tests/IntegrationTest/test"
 
       - name: Print logs on failure
         if: ${{ failure() }}

--- a/.github/workflows/nightly-pekko1.0.yml
+++ b/.github/workflows/nightly-pekko1.0.yml
@@ -1,0 +1,88 @@
+name: Nightly Test with Pekko 1.0 libs
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * *"
+    
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }} @ ${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PEKKO_TEST_TIMEFACTOR: 10.0
+  EVENT_NAME: ${{ github.event_name }}
+
+jobs:  
+  test:
+    name: Build and Test with Pekko 1.0
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { java-version: 8,  scala-version: 2.12, sbt-opts: '' }
+          - { java-version: 8,  scala-version: 2.13, sbt-opts: '' }
+          - { java-version: 8,  scala-version: 3.3, sbt-opts: '' }
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Checkout GitHub merge
+        if: github.event.pull_request
+        run: |-
+          git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
+          git checkout scratch
+
+      - name: Setup Java ${{ matrix.java-version }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java-version }}
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v6
+
+      - name: Run tests with Scala ${{ matrix.scala-version }} and Java ${{ matrix.java-version }}
+        run: sbt -Dpekko.build.pekko.version=1.0.x "++${{ matrix.scala-version }} test" ${{ matrix.sbt-opts }}
+
+      - name: Print logs on failure
+        if: ${{ failure() }}
+        run: find . -name "*.log" -exec ./scripts/cat-log.sh {} \;
+
+  integration-test:
+    name: Integration tests with Pekko 1.0
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Checkout GitHub merge
+        if: github.event.pull_request
+        run: |-
+          git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
+          git checkout scratch
+
+      - name: Setup Java 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 8
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v6
+
+      - name: Run multi-broker and long running integration tests
+        run: sbt -Dpekko.build.pekko.version=1.0.x "tests/IntegrationTest/test"
+
+      - name: Print logs on failure
+        if: ${{ failure() }}
+        run: find . -name "*.log" -exec ./scripts/cat-log.sh {} \;

--- a/project/PekkoCoreDependency.scala
+++ b/project/PekkoCoreDependency.scala
@@ -20,5 +20,5 @@ import com.github.pjfanning.pekkobuild.PekkoDependency
 object PekkoCoreDependency extends PekkoDependency {
   override val checkProject: String = "pekko-cluster-sharding-typed"
   override val module: Option[String] = None
-  override val currentVersion: String = "1.0.2"
+  override val currentVersion: String = "1.1.0-M1"
 }


### PR DESCRIPTION
* most pekko repos now use pekko 1.1 dependencies in main branch
* add nightly test run that checks code still works with pekko 1.0 libs