### PR TITLE
add asm.ow2.io exception in link validator

### DIFF
--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -60,5 +60,6 @@ site-link-validator {
     "http://www.scalatest.org",
     "http://www.slf4j.org",
     "http://www.snakeyaml.org"
+    "http://asm.ow2.io/"
   ]
 }


### PR DESCRIPTION
* has started causing link validation issues in a few pekko repos
* license report is where this link is now appearing