### PR TITLE
issue in license report

### DIFF
--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -48,6 +48,7 @@ site-link-validator {
     "http://www.eclipse.org/legal/epl-v10.html",
     "http://findbugs.sourceforge.net",
     "http://github.com/FasterXML/jackson",
+    "http://github.com/google/re2j"
     "http://github.com/jnr/",
     "http://www.gnu.org/licenses/"
     "http://hamcrest.org/JavaHamcrest/",


### PR DESCRIPTION
http link now appearing in license report - breaking link validator check