### PR TITLE
nightly tests always need access to snapshot jars

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,8 +15,7 @@ sourceDistName := "apache-pekko-connectors-kafka"
 sourceDistIncubating := false
 
 ThisBuild / reproducibleBuildsCheckResolver := Resolver.ApacheMavenStagingRepo
-// FIXME can we optimized it? https://github.com/apache/pekko-connectors-kafka/pull/193
-ThisBuild / resolvers ++= (if (isSnapshot.value) Seq(Resolver.ApacheMavenSnapshotsRepo) else Seq())
+ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo
 
 addCommandAlias("verifyCodeStyle", "scalafmtCheckAll; scalafmtSbtCheck; +headerCheckAll; javafmtCheckAll")
 addCommandAlias("applyCodeStyle", "+headerCreateAll; scalafmtAll; scalafmtSbt; javafmtAll")


### PR DESCRIPTION
I noticed the nightly tests have been failing after we set the git tags for the release