### PR TITLE
broken link in releases-1.0.md

### DIFF
--- a/docs/src/main/paradox/release-notes/releases-1.0.md
+++ b/docs/src/main/paradox/release-notes/releases-1.0.md
@@ -9,7 +9,7 @@ Apache Pekko has changed the package names, among other changes. The new package
 
 Config names have changed to use `pekko` instead of `akka` in their names.
 
-Users switching from Akka to Pekko should read our [Migration Guide](https://pekko.apache.org/docs/pekko/current/project/migration-guides.html).
+Users switching from Akka to Pekko should read our [Migration Guide](https://pekko.apache.org/docs/pekko/1.0/project/migration-guides.html).
 
 Generally, we have tried to make it as easy as possible to switch existing Akka based projects over to using Pekko.
 


### PR DESCRIPTION
pekko current now points at 1.1.1 docs and the migration guide has changed - breaking this link