### PR TITLE
allow check-build-test to run for 1.0.x branch

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - release-*
+      - 1.0.x
     tags-ignore: [ v.* ]
     
 permissions: {}


### PR DESCRIPTION
the checks in this CI job are needed for 1.0.x PRs - see #227 - this PR is blocked because this job did not run