### PR TITLE
use versioned links

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -20,9 +20,9 @@ object Versions {
   val Scala212 = "2.12.20"
   val Scala3 = "3.3.4"
 
-  val pekkoVersionForDocs = "current"
-  val pekkoConnectorsKafkaVersionForDocs = "current"
-  val pekkoManagementVersionForDocs = "current"
+  val pekkoVersionForDocs = PekkoCoreDependency.default.link
+  val pekkoConnectorsKafkaVersionForDocs = PekkoConnectorsKafkaDependency.default.link
+  val pekkoManagementVersionForDocs = PekkoManagementDependency.default.link
 
   val kafkaVersion = "3.8.0"
   val KafkaVersionForDocs = "37"


### PR DESCRIPTION
* instead of linking to 'current' - use 1.0/1.1 links as appropriate
* we've made the same change in most modules