### PR TITLE
fix broken akka link (1.0 docs)

### DIFF
--- a/docs/src/main/paradox/release-notes/index.md
+++ b/docs/src/main/paradox/release-notes/index.md
@@ -20,7 +20,7 @@ properly acknowledged, please get in touch.
 ### Bug Fixes
 We haven't had to fix many significant bugs that were in Alpakka Kafka 3.0.1.
 
-* Properly mask all sensitive fields in Consumer and Producer settings [PR100](https://github.com/apache/pekko-connectors-kafka/pull/100) (Alpakka Kafka [CVE-2023-29471](https://akka.io/security/alpakka-kafka-cve-2023-29471.html))
+* Properly mask all sensitive fields in Consumer and Producer settings [PR100](https://github.com/apache/pekko-connectors-kafka/pull/100) (Alpakka Kafka [CVE-2023-29471](https://doc.akka.io/reference/security-announcements/alpakka-kafka-cve-2023-29471.html))
 
 ### Additions
 


### PR DESCRIPTION
* see #264 
* doc format in 1.0 is a bit different making cherry pick harder