### PR TITLE
test with latest available confluent images

### DIFF
--- a/docs/src/main/paradox/serialization.md
+++ b/docs/src/main/paradox/serialization.md
@@ -66,7 +66,7 @@ Maven
         <dependency>
           <groupId>io.confluent</groupId>
           <artifactId>kafka-avro-serializer</artifactId>
-          <version>confluent.version (eg. 5.0.0)</version>
+          <version>confluent.version (eg. 7.9.0)</version>
         </dependency>
         ...
       </dependencies>
@@ -84,14 +84,14 @@ Maven
 
 sbt
 :   ```scala
-    libraryDependencies += "io.confluent" % "kafka-avro-serializer" % confluentAvroVersion, //  eg. 5.0.0
+    libraryDependencies += "io.confluent" % "kafka-avro-serializer" % confluentAvroVersion, //  eg. 7.9.0
     resolvers += "Confluent Maven Repository" at "https://packages.confluent.io/maven/",
     ```
 
 Gradle
 :   ```gradle
     dependencies {
-      compile group: 'io.confluent', name: 'kafka-avro-serializer', version: confluentAvroVersion // eg. 5.0.0
+      compile group: 'io.confluent', name: 'kafka-avro-serializer', version: confluentAvroVersion // eg. 7.9.0
     }
     repositories {
       maven {

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -28,7 +28,7 @@ pekko.kafka.testkit.testcontainers {
   schema-registry-image = "confluentinc/cp-schema-registry"
   schema-registry-image-tag = ${pekko.kafka.testkit.testcontainers.confluent-platform-version}
   # See https://docs.confluent.io/platform/current/installation/versions-interoperability.html
-  confluent-platform-version = "7.0.0"
+  confluent-platform-version = "7.8.2"
 
   # the number of Kafka brokers to include in a test cluster
   num-brokers = 1

--- a/tests/src/test/scala/org/apache/pekko/kafka/scaladsl/RetentionPeriodSpec.scala
+++ b/tests/src/test/scala/org/apache/pekko/kafka/scaladsl/RetentionPeriodSpec.scala
@@ -30,13 +30,10 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class RetentionPeriodSpec extends SpecBase with TestcontainersKafkaPerClassLike {
-  private final val confluentPlatformVersion = "5.0.0"
+  // https://docs.confluent.io/current/installation/versions-interoperability.html
+  private final val confluentPlatformVersion = "7.8.2"
 
   override val testcontainersSettings = KafkaTestkitTestcontainersSettings(system)
-    // The bug commit refreshing circumvents was fixed in Kafka 2.1.0
-    // https://issues.apache.org/jira/browse/KAFKA-4682
-    // Confluent Platform 5.0.0 bundles Kafka 2.0.0
-    // https://docs.confluent.io/current/installation/versions-interoperability.html
     .withKafkaImageTag(confluentPlatformVersion)
     .withZooKeeperImageTag(confluentPlatformVersion)
     .withInternalTopicsReplicationFactor(1)


### PR DESCRIPTION
The docker images we test with are from Confluent. We are using old images.