### PR TITLE
add testcontainers ref to license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -205,3 +205,32 @@
 pekko-connectors-kafka-cluster-sharding contains KafkaClusterSharding.scala.
 This code is derived from a class in Apache Kafka <https://kafka.apache.org/>,
 licensed under the Apache 2.0 license.
+
+---------------
+
+pekko-connectors-kafka-testkit contains PekkoConnectorsKafkaContainer.scala.
+This code is derived from a class in testcontainers-java
+<https://github.com/testcontainers/testcontainers-java/>,
+licensed under the MIT License.
+
+The MIT License (MIT)
+
+Copyright (c) 2015-2019 Richard North
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/internal/PekkoConnectorsKafkaContainer.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/internal/PekkoConnectorsKafkaContainer.java
@@ -40,7 +40,7 @@ public class PekkoConnectorsKafkaContainer extends GenericContainer<PekkoConnect
   private static final String STARTER_SCRIPT = "/testcontainers_start.sh";
 
   // Align these confluent platform constants with testkit/src/main/resources/reference.conf
-  public static final String DEFAULT_CONFLUENT_PLATFORM_VERSION = "6.1.1";
+  public static final String DEFAULT_CONFLUENT_PLATFORM_VERSION = "7.8.2";
 
   public static final DockerImageName DEFAULT_ZOOKEEPER_IMAGE_NAME =
       DockerImageName.parse("confluentinc/cp-zookeeper")


### PR DESCRIPTION
I noticed this line in the javadoc

https://github.com/apache/pekko-connectors-kafka/blob/3dda6f4fdcb46e3a5d5c30adfc4f7acb2a391173/testkit/src/main/java/org/apache/pekko/kafka/testkit/internal/PekkoConnectorsKafkaContainer.java#L32