### PR TITLE
Test with Confluent 7.9.0 docker images

### DIFF
--- a/testkit/src/main/java/org/apache/pekko/kafka/testkit/internal/PekkoConnectorsKafkaContainer.java
+++ b/testkit/src/main/java/org/apache/pekko/kafka/testkit/internal/PekkoConnectorsKafkaContainer.java
@@ -40,7 +40,7 @@ public class PekkoConnectorsKafkaContainer extends GenericContainer<PekkoConnect
   private static final String STARTER_SCRIPT = "/testcontainers_start.sh";
 
   // Align these confluent platform constants with testkit/src/main/resources/reference.conf
-  public static final String DEFAULT_CONFLUENT_PLATFORM_VERSION = "7.8.2";
+  public static final String DEFAULT_CONFLUENT_PLATFORM_VERSION = "7.9.0";
 
   public static final DockerImageName DEFAULT_ZOOKEEPER_IMAGE_NAME =
       DockerImageName.parse("confluentinc/cp-zookeeper")

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -28,7 +28,7 @@ pekko.kafka.testkit.testcontainers {
   schema-registry-image = "confluentinc/cp-schema-registry"
   schema-registry-image-tag = ${pekko.kafka.testkit.testcontainers.confluent-platform-version}
   # See https://docs.confluent.io/platform/current/installation/versions-interoperability.html
-  confluent-platform-version = "7.8.2"
+  confluent-platform-version = "7.9.0"
 
   # the number of Kafka brokers to include in a test cluster
   num-brokers = 1

--- a/tests/src/test/scala/org/apache/pekko/kafka/scaladsl/RetentionPeriodSpec.scala
+++ b/tests/src/test/scala/org/apache/pekko/kafka/scaladsl/RetentionPeriodSpec.scala
@@ -31,7 +31,7 @@ import scala.concurrent.duration._
 
 class RetentionPeriodSpec extends SpecBase with TestcontainersKafkaPerClassLike {
   // https://docs.confluent.io/current/installation/versions-interoperability.html
-  private final val confluentPlatformVersion = "7.8.2"
+  private final val confluentPlatformVersion = "7.9.0"
 
   override val testcontainersSettings = KafkaTestkitTestcontainersSettings(system)
     .withKafkaImageTag(confluentPlatformVersion)


### PR DESCRIPTION
trying to test with newest Kafka releases - unfortunately, Confluent have not yet released a Kafka 4 based Confluent Docker releases.