### PR TITLE
remove old ref for no longer existing config

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -66,7 +66,7 @@ pekko.kafka.consumer {
 
   # Tuning property of the `KafkaConsumer.poll` parameter.
   # Note that non-zero value means that the thread that
-  # is executing the stage will be blocked. See also the `wakup-timeout` setting below.
+  # is executing the stage will be blocked.
   poll-timeout = 50ms
 
   # The stage will delay stopping the internal actor to allow processing of


### PR DESCRIPTION
probably gone since https://github.com/akka/alpakka-kafka/pull/686/files