### PR TITLE
Clean up dependency version pinning in config

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -2,21 +2,8 @@ updates.ignore = [
 ]
 
 updates.pin = [
-  # Pin sbt-paradox to v0.9.x because 0.10.x needs JDK 11
-  { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox-project-info", version = "0.9." },
-  { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox", version = "0.9." }
-  # Pin sbt-java-formatter to v0.9.x because 0.10.x needs JDK 11
-  { groupId = "com.github.sbt", artifactId = "sbt-java-formatter", version = "0.9." }
-  # Pin logback to v1.3.x because v1.4.x needs JDK11
-  { groupId = "ch.qos.logback", version="1.3." }
-  # https://github.com/apache/pekko/issues/1202
-  { groupId = "com.fasterxml.jackson.core", version="2.17." }
   # Scala 3.3 is a LTS
   { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.3." }
-  # protobuf 4 is not well supported
-  { groupId = "com.google.protobuf", artifactId = "protobuf-java", version = "3." }
-  # Mockito 5 requires Java 11+
-  { groupId = "org.mockito", artifactId = "mockito-core", version = "4." }
 ]
 
 updatePullRequests = "always"


### PR DESCRIPTION
Now that we no longer support java 8